### PR TITLE
[#22] Environment configuration

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,0 +1,13 @@
+# Server Configuration
+NODE_ENV=development
+PORT=3000
+
+# Database
+# For local development, use file-based SQLite
+DATABASE_URL=file:local.db
+# For Turso cloud database:
+# DATABASE_URL=libsql://your-database.turso.io
+# TURSO_AUTH_TOKEN=your-auth-token
+
+# CORS (comma-separated list of allowed origins)
+CORS_ORIGINS=http://localhost:5173

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  // Server
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  PORT: z.coerce.number().default(3000),
+
+  // Database
+  DATABASE_URL: z.string().default('file:local.db'),
+
+  // CORS (comma-separated list of origins)
+  CORS_ORIGINS: z.string().default('http://localhost:5173'),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+function loadEnv(): Env {
+  const result = envSchema.safeParse(process.env);
+
+  if (!result.success) {
+    // eslint-disable-next-line no-console
+    console.error('Invalid environment variables:');
+    // eslint-disable-next-line no-console
+    console.error(result.error.format());
+    process.exit(1);
+  }
+
+  return result.data;
+}
+
+export const env = loadEnv();

--- a/packages/backend/src/db/client.ts
+++ b/packages/backend/src/db/client.ts
@@ -1,10 +1,11 @@
 import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
 import * as schema from './schema.js';
+import { env } from '../config/env.js';
 
 // Initialize libSQL client
 const client = createClient({
-  url: process.env.DATABASE_URL || 'file:local.db',
+  url: env.DATABASE_URL,
 });
 
 // Initialize Drizzle ORM

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -3,14 +3,18 @@ import cors from 'cors';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import type { Express } from 'express';
 
-import { appRouter } from './trpc/appRouter';
+import { appRouter } from './trpc/appRouter.js';
+import { env } from './config/env.js';
 
 const app: Express = express();
-const PORT = process.env.PORT || 3000;
 
 // Middleware
 app.use(express.json());
-app.use(cors());
+app.use(
+  cors({
+    origin: env.CORS_ORIGINS.split(',').map((o) => o.trim()),
+  })
+);
 
 // tRPC API route
 app.use(
@@ -27,9 +31,11 @@ app.get('/health', (_req, res) => {
 });
 
 // Start server
-app.listen(PORT, () => {
-  console.log(`🚀 Resonance backend server running on port ${PORT}`);
-  console.log(`📝 tRPC API available at http://localhost:${PORT}/api/trpc`);
+app.listen(env.PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`🚀 Resonance backend server running on port ${env.PORT}`);
+  // eslint-disable-next-line no-console
+  console.log(`📝 tRPC API available at http://localhost:${env.PORT}/api/trpc`);
 });
 
 export default app;

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,0 +1,2 @@
+# API Configuration
+VITE_API_URL=http://localhost:3000

--- a/packages/frontend/src/config/env.ts
+++ b/packages/frontend/src/config/env.ts
@@ -1,0 +1,8 @@
+// Frontend environment configuration
+// Vite exposes env vars prefixed with VITE_ at build time
+
+export const env = {
+  apiUrl: import.meta.env.VITE_API_URL || 'http://localhost:3000',
+  isDev: import.meta.env.DEV,
+  isProd: import.meta.env.PROD,
+} as const;

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- Add Zod-based environment validation for backend (validates at startup)
- Create `.env.example` files documenting required variables
- Add type-safe env config for frontend using Vite's import.meta.env
- Add `vite-env.d.ts` for TypeScript support

**Note**: This PR is stacked on #33 (feature/21-dev-tooling)

Closes #22

## Environment Variables

### Backend
- `NODE_ENV` - development/production/test (default: development)
- `PORT` - Server port (default: 3000)
- `DATABASE_URL` - libSQL connection URL (default: file:local.db)
- `CORS_ORIGINS` - Comma-separated allowed origins

### Frontend
- `VITE_API_URL` - Backend API URL (default: http://localhost:3000)

## Test plan
- [x] `npm run type-check` passes
- [x] Backend validates env on startup
- [x] Frontend has typed env config

🤖 Generated with [Claude Code](https://claude.com/claude-code)