### PR TITLE
[#23] Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Dependencies
+node_modules
+*/node_modules
+
+# Build outputs
+dist
+*/dist
+.next
+out
+build
+
+# Development files
+.git
+.gitignore
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+logs
+
+# Test files
+coverage
+.nyc_output
+*.test.ts
+*.spec.ts
+__tests__
+
+# Documentation
+*.md
+!README.md
+docs
+
+# Data (will be mounted as volume)
+data
+*.db
+*.sqlite
+
+# Temporary files
+tmp
+temp
+*.tmp
+
+# Local config
+.claude
+.serena
+.mcp.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Build stage for frontend
+FROM node:20-alpine AS frontend-build
+WORKDIR /app
+COPY package*.json ./
+COPY packages/frontend/package.json ./packages/frontend/
+COPY packages/shared/package.json ./packages/shared/
+RUN npm ci --workspace=@resonance/frontend --workspace=@resonance/shared
+COPY packages/shared ./packages/shared
+COPY packages/frontend ./packages/frontend
+COPY tsconfig.json ./
+RUN npm run build --workspace=@resonance/shared
+RUN npm run build --workspace=@resonance/frontend
+
+# Build stage for backend
+FROM node:20-alpine AS backend-build
+WORKDIR /app
+COPY package*.json ./
+COPY packages/backend/package.json ./packages/backend/
+COPY packages/shared/package.json ./packages/shared/
+RUN npm ci --workspace=@resonance/backend --workspace=@resonance/shared
+COPY packages/shared ./packages/shared
+COPY packages/backend ./packages/backend
+COPY tsconfig.json ./
+RUN npm run build --workspace=@resonance/shared
+RUN npm run build --workspace=@resonance/backend
+
+# Production stage
+FROM node:20-alpine AS production
+WORKDIR /app
+
+# Install production dependencies only
+COPY package*.json ./
+COPY packages/backend/package.json ./packages/backend/
+COPY packages/shared/package.json ./packages/shared/
+RUN npm ci --workspace=@resonance/backend --workspace=@resonance/shared --omit=dev
+
+# Copy built artifacts
+COPY --from=backend-build /app/packages/backend/dist ./packages/backend/dist
+COPY --from=backend-build /app/packages/shared/dist ./packages/shared/dist
+COPY --from=frontend-build /app/packages/frontend/dist ./packages/frontend/dist
+
+# Create data directory
+RUN mkdir -p /app/data
+
+# Environment defaults
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV DATABASE_URL=file:/app/data/resonance.db
+
+# Expose port
+EXPOSE 3000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
+
+# Start server
+CMD ["node", "packages/backend/dist/index.js"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,29 @@
+# Development Dockerfile with hot reload support
+
+# Backend development
+FROM node:20-alpine AS backend-dev
+WORKDIR /app
+COPY package*.json ./
+COPY packages/backend/package.json ./packages/backend/
+COPY packages/shared/package.json ./packages/shared/
+RUN npm ci
+COPY tsconfig.json ./
+COPY packages/shared ./packages/shared
+COPY packages/backend ./packages/backend
+RUN npm run build --workspace=@resonance/shared
+EXPOSE 3000
+CMD ["npm", "run", "dev", "--workspace=@resonance/backend"]
+
+# Frontend development
+FROM node:20-alpine AS frontend-dev
+WORKDIR /app
+COPY package*.json ./
+COPY packages/frontend/package.json ./packages/frontend/
+COPY packages/shared/package.json ./packages/shared/
+RUN npm ci
+COPY tsconfig.json ./
+COPY packages/shared ./packages/shared
+COPY packages/frontend ./packages/frontend
+RUN npm run build --workspace=@resonance/shared
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--workspace=@resonance/frontend", "--", "--host"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '3.8'
+
+services:
+  # Development backend service
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      target: backend-dev
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./packages/backend/src:/app/packages/backend/src
+      - ./packages/shared/src:/app/packages/shared/src
+      - ./data:/app/data
+    environment:
+      - NODE_ENV=development
+      - PORT=3000
+      - DATABASE_URL=file:/app/data/resonance.db
+      - CORS_ORIGINS=http://localhost:5173
+    command: npm run dev --workspace=@resonance/backend
+
+  # Development frontend service
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      target: frontend-dev
+    ports:
+      - '5173:5173'
+    volumes:
+      - ./packages/frontend/src:/app/packages/frontend/src
+      - ./packages/shared/src:/app/packages/shared/src
+    environment:
+      - VITE_API_URL=http://localhost:3000
+    command: npm run dev --workspace=@resonance/frontend -- --host
+    depends_on:
+      - backend
+
+  # Production service (single container serving both frontend and backend)
+  production:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./data:/app/data
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DATABASE_URL=file:/app/data/resonance.db
+      - CORS_ORIGINS=http://localhost:3000
+    profiles:
+      - prod
+
+volumes:
+  data:

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,10 +1,15 @@
 import express from 'express';
 import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import type { Express } from 'express';
 
 import { appRouter } from './trpc/appRouter.js';
 import { env } from './config/env.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app: Express = express();
 
@@ -29,6 +34,17 @@ app.use(
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
+
+// Serve frontend static files in production
+if (env.NODE_ENV === 'production') {
+  const frontendPath = path.join(__dirname, '../../frontend/dist');
+  app.use(express.static(frontendPath));
+
+  // SPA fallback - serve index.html for client-side routing
+  app.get('*', (_req, res) => {
+    res.sendFile(path.join(frontendPath, 'index.html'));
+  });
+}
 
 // Start server
 app.listen(env.PORT, () => {


### PR DESCRIPTION
## Summary
- Add production Dockerfile with multi-stage build (frontend + backend)
- Add development Dockerfile.dev with hot reload support
- Add docker-compose.yml for local development workflow
- Add .dockerignore to optimize build context
- Update backend to serve frontend static files in production mode

**Note**: This PR is stacked on #34 (feature/22-env-config)

Closes #23

## Usage

### Development
```bash
docker compose up
```
- Backend: http://localhost:3000
- Frontend: http://localhost:5173

### Production
```bash
docker compose --profile prod up production
```
- Single container serving both frontend and backend on port 3000

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes (only warnings)
- [ ] Docker build completes (requires Docker daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)